### PR TITLE
Fix type fonction target CDPOptions

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -472,7 +472,7 @@ declare namespace MCR {
         /** enable https, defaults to false (http) */
         secure?: boolean;
         /** target filter, defaults to first page */
-        target?: (targets) => any;
+        target?: (targets: any) => any;
         /** websocket options */
         ws?: any;
         /** timeout, defaults to 10 * 1000 */


### PR DESCRIPTION
Hi,

Thanks for the work you have done for enhance playwright experience :) .

With strict option in my angular project i got this following error : 

```
[ERROR] TS7006: Parameter 'targets' implicitly has an 'any' type. [plugin angular-compiler]

    node_modules/monocart-coverage-reports/lib/index.d.ts:467:18:
      467 │         target?: (targets) => any;
          ╵                   ~~~~~~~
```

I add any type to parameter targets and now it compiles.

I am not sure if we can put another type than any ...