### PR TITLE
fix: fix typings of the `reports` option

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -222,7 +222,7 @@ declare namespace MCR {
          * 
          * By default, `v8` for V8 data, `html` for Istanbul data
          */
-        reports?: string | string[] | ReportDescription[];
+        reports?: string | (string | ReportDescription)[];
 
         /** {string} output dir */
         outputDir?: string;


### PR DESCRIPTION
Documentation of the `reports` option mentions that it could be specified like this: `['v8', ['console-details', { skipPercent: 80 }]]`.

Currently that raises a TypeScript type error:

<img width="652" alt="Screenshot 2024-06-13 at 16 16 04" src="https://github.com/cenfun/monocart-coverage-reports/assets/72159681/7180e027-beff-4134-adc1-5f8276aaf7ee">

This PR is fixing the problem. I checked this manually.

By the way, I could open a separate PR to add type tests. That is just the right job for [TSTyche](https://github.com/tstyche/tstyche), a type testing tool which I created. Let me know if that sounds interesting.