### PR TITLE
Add close() to CoverageClient type definition

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -544,6 +544,8 @@ declare namespace MCR {
          * @param coverageKey defaults to `__coverage__`
          */
         getIstanbulCoverage: (coverageKey?: string) => Promise<any>;
+
+        close: () => Promise<void>
     }
 
     /** Adapt to the CDPSession of Playwright or Puppeteer */


### PR DESCRIPTION
The `close()` function was missing from the type definitions, but it was used in many examples. 
This caused typescript errors.