### PR TITLE
fix runtime panic if sourceContent is falsy

### DIFF
--- a/lib/converter/converter.js
+++ b/lib/converter/converter.js
@@ -1037,6 +1037,11 @@ const initOriginalList = (state, originalDecodedMap, options) => {
         // console.log(sourcePath);
 
         // console.log(`add source: ${k}`);
+        if (!sourceContent) {
+            Util.logError(`not found content in source map: ${sourcePath}`);
+            return;
+        }
+
         const sourceContent = sourcesContent[sourceIndex];
         if (typeof sourceContent !== 'string') {
             Util.logError(`not found source content: ${sourcePath}`);


### PR DESCRIPTION
## Description

I encountered an issue when generating code coverage reports while using module SCSS files.
After debugging, I discovered that the `sourceContent` property in `state.sourceMap` could be falsy, causing the monocart-coverage-reports library to throw an error due to inadequate null checking.

## Full error log

```txt
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
TypeError: Cannot read properties of undefined (reading '0')
 ❯ ../../node_modules/monocart-coverage-reports/lib/converter/converter.js:1045:45
 ❯ initOriginalList ../../node_modules/monocart-coverage-reports/lib/converter/converter.js:1029:13
 ❯ unpackSourceMap ../../node_modules/monocart-coverage-reports/lib/converter/converter.js:1213:30
 ❯ unpackDistFile ../../node_modules/monocart-coverage-reports/lib/converter/converter.js:1264:9
 ❯ convertCoverages ../../node_modules/monocart-coverage-reports/lib/converter/converter.js:1498:9
 ❯ convertV8List ../../node_modules/monocart-coverage-reports/lib/converter/converter.js:1813:23
 ❯ getCoverageResults ../../node_modules/monocart-coverage-reports/lib/generate.js:178:31
 ❯ generateCoverageReports ../../node_modules/monocart-coverage-reports/lib/generate.js:197:29
 ❯ CoverageReport.generate ../../node_modules/monocart-coverage-reports/lib/index.js:173:33




 ELIFECYCLE  Test failed. See above for more details.
```

## Solution

I added a guard condition to check if `sourceContent` exists before attempting to access it, which prevents accessing properties on `undefined` or `null` values.