### PR TITLE
fix: typo in `lib/index.d.ts`

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -419,7 +419,7 @@ declare namespace MCR {
         /**
          * {function} Custom resolver for sourcemap content
          */
-        sourceMapResolver?: (url: string, defaultResolver: function) => Promise<any>;
+        sourceMapResolver?: (url: string, defaultResolver: Function) => Promise<any>;
 
         /** (V8 only) {function} onEntry hook */
         onEntry?: (entry: V8CoverageEntry) => Promise<void>;


### PR DESCRIPTION
Seems like there is a typo in `lib/index.d.ts`. Should this be the `Function` type, perhaps?

I got a failure reported here: https://github.com/tstyche/tstyche/actions/runs/15034716093/job/42254235639?pr=488